### PR TITLE
Typo causes NameError when pressing the left arrow key.

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -176,8 +176,8 @@ def gui(stdscr, inqueue, outqueue):
 			elif c == curses.KEY_UP:
 				index = (index-1)%len(settings)
 			elif c == curses.KEY_LEFT:
-				setting[index].dec(last_param_msg)
-				setting[index].changed = True
+				settings[index].dec(last_param_msg)
+				settings[index].changed = True
 			elif c == curses.KEY_RIGHT:
 				settings[index].inc(last_param_msg)
 				settings[index].changed = True


### PR DESCRIPTION
Looks like a typo occurred when the name of a dictionary was changed from data to settings. This was causing the left arrow key to throw an exception.
